### PR TITLE
Dead champions should not act

### DIFF
--- a/gupb/model/characters.py
+++ b/gupb/model/characters.py
@@ -43,11 +43,12 @@ class Champion:
         return ChampionDescription(self.controller.name, self.health, self.weapon.description(), self.facing)
 
     def act(self) -> None:
-        action = self.pick_action()
-        verbose_logger.debug(f"Champion {self.controller.name} picked action {action}.")
-        ChampionPickedActionReport(self.controller.name, action.name).log(logging.DEBUG)
-        action(self)
-        self.arena.stay(self)
+        if self.alive:
+            action = self.pick_action()
+            verbose_logger.debug(f"Champion {self.controller.name} picked action {action}.")
+            ChampionPickedActionReport(self.controller.name, action.name).log(logging.DEBUG)
+            action(self)
+            self.arena.stay(self)
 
     # noinspection PyBroadException
     def pick_action(self) -> Action:


### PR DESCRIPTION
Prevent champions from acting after dying .

## Related Issue
This bug was the root cause of errors when controllers tried to access their champion data through `knowledge.visible_tiles[knowledge.position].character` which returned `None` as the champion was already removed from arena.

## Logs:
```json
{"time_stamp": "2020-10-13 19:17:17,556", "severity": "DEBUG", "line": "core.log:11", "type": "ChampionPickedActionReport", "value": {"controller_name": "IHaveNoIdeaWhatImDoingController", "action_name": "ATTACK"}}
{"time_stamp": "2020-10-13 19:17:17,556", "severity": "DEBUG", "line": "core.log:11", "type": "ChampionAttackReport", "value": {"controller_name": "IHaveNoIdeaWhatImDoingController", "weapon_name": "bow"}}
{"time_stamp": "2020-10-13 19:17:17,583", "severity": "DEBUG", "line": "core.log:11", "type": "ChampionDamagedByWeaponCutReport", "value": {"controller_name": "BBBotControllerBartek", "damage": 1}}
{"time_stamp": "2020-10-13 19:17:17,583", "severity": "DEBUG", "line": "core.log:11", "type": "ChampionWoundsReport", "value": {"controller_name": "BBBotControllerBartek", "wounds": 1, "rest_health": 0}}
{"time_stamp": "2020-10-13 19:17:17,584", "severity": "DEBUG", "line": "core.log:11", "type": "ChampionDeathReport", "value": {"controller_name": "BBBotControllerBartek"}}
...
{"time_stamp": "2020-10-13 19:17:17,779", "severity": "WARNING", "line": "core.log:11", "type": "ControllerExceptionReport", "value": {"controller_name": "BBBotControllerBartek", "exception": "AttributeError(\"'NoneType' object has no attribute 'facing'\")"}}
{"time_stamp": "2020-10-13 19:17:17,779", "severity": "DEBUG", "line": "core.log:11", "type": "ChampionPickedActionReport", "value": {"controller_name": "BBBotControllerBartek", "action_name": "DO_NOTHING"}}
```